### PR TITLE
Add Development Projects section

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,6 +203,111 @@
         </div>
       </article>
     </section>
+
+    <section>
+      <h3>Development Projects</h3>
+      <article>
+        <div class='job-title'>
+          <span>2026 – present</span> <strong>Procode Academy Website</strong><br>
+          <strong>Type:</strong> WordPress / WooCommerce Theme Development
+        </div>
+        <div>
+          <p><strong>Tech stack:</strong> WordPress / WooCommerce / HTML5 / CSS3 / PHP / Git</p>
+          <p><strong>Links:</strong> 
+            <a href="https://www.procode.sk">Project website</a> | 
+            <a href="https://github.com/Rosko00/procode/">GitHub repository</a>
+          </p>
+          <ul class="job-description">
+            <li>Develop and customize a WordPress theme for an online learning platform</li>
+            <li>Implement WooCommerce functionality for online course sales</li>
+            <li>Create responsive frontend components using HTML5 and CSS3</li>
+            <li>Integrate UI sections based on project specifications</li>
+            <li>Prepare theme for WooCommerce compatibility and production deployment</li>
+            <li>Collaborate using Git workflow (branches, commits, pull requests)</li>
+          </ul>
+        </div>
+      </article>
+
+      <article>
+        <div class='job-title'>
+          <span>2025 – present</span> <strong>ContiApp – Web Application</strong><br>
+          <strong>Type:</strong> PHP Web Application Project
+        </div>
+        <div>
+          <p><strong>Tech stack:</strong> PHP / HTML / CSS / Git</p>
+          <p><strong>Links:</strong> 
+            <a href="https://github.com/Rosko00/contiapp_3/">GitHub repository</a>
+          </p>
+          <ul class="job-description">
+            <li>Collaborate on development of a PHP-based web application</li>
+            <li>Contribute to applications used by industrial clients (e.g. Continental AG)</li>
+            <li>Implement layout and page structure adjustments using HTML and CSS</li>
+            <li>Gain orientation in backend logic and application architecture</li>
+            <li>Use Git and GitHub for version control and collaboration</li>
+          </ul>
+        </div>
+      </article>
+
+      <article>
+        <div class='job-title'>
+          <span>2026 – present</span> <strong>Procode Intranet Application</strong><br>
+          <strong>Type:</strong> Internal Web Application
+        </div>
+        <div>
+          <p><strong>Tech stack:</strong> PHP / HTML5 / CSS3 / Git / Docker</p>
+          <p><strong>Links:</strong> 
+            <a href="https://github.com/Rosko00/Intranet/">GitHub repository</a>
+          </p>
+          <ul class="job-description">
+            <li>Develop internal web-based intranet application</li>
+            <li>Implement UI components and layout using HTML5 and CSS3</li>
+            <li>Participate in backend-oriented functionality and application structure</li>
+            <li>Collaborate with developers in Agile Scrum environment</li>
+            <li>Use Git for version control and team collaboration</li>
+          </ul>
+        </div>
+      </article>
+
+      <article>
+        <div class='job-title'>
+          <span>2026 – present</span> <strong>Online CV – Personal Portfolio Website</strong><br>
+          <strong>Type:</strong> Personal Developer Portfolio
+        </div>
+        <div>
+          <p><strong>Tech stack:</strong> HTML5 / CSS3 / GitHub / Responsive Design</p>
+          <p><strong>Links:</strong> 
+            <a href="https://cv.jaroslavtakac.sk">Live website</a> | 
+            <a href="https://github.com/jaroslav-takac/online-cv/">GitHub repository</a>
+          </p>
+          <ul class="job-description">
+            <li>Design and develop a personal online CV and portfolio website</li>
+            <li>Create responsive layout using semantic HTML and CSS</li>
+            <li>Present professional experience, skills and development projects</li>
+            <li>Deploy and manage the project using Git and GitHub</li>
+          </ul>
+        </div>
+      </article>
+
+      <article>
+        <div class='job-title'>
+          <span>2024 – present</span> <strong>Collectors Web & Shop</strong><br>
+          <strong>Type:</strong> Hobby E-commerce Website & Blog
+        </div>
+        <div>
+          <p><strong>Tech stack:</strong> CMS / HTML / CSS / SEO</p>
+          <p><strong>Links:</strong> 
+            <a href="https://jtcollector.sk/">Live website</a>
+          </p>
+          <ul class="job-description">
+            <li>Manage web platform with more than 7,000 products</li>
+            <li>Structure product catalog and categories</li>
+            <li>Customize layout and templates using HTML and CSS</li>
+            <li>Create blog articles and optimize content using SEO best practices</li>
+            <li>Gain practical experience with CMS workflows and web publishing</li>
+          </ul>
+        </div>
+      </article>
+    </section>
   </main>
 
   <footer>


### PR DESCRIPTION
## Summary
Add a new "Development Projects" section to the Online CV.

The section highlights selected development projects and practical experience, including:

- Procode Academy Website (WordPress / WooCommerce theme development)
- ContiApp – PHP Web Application
- Procode Intranet Application
- Online CV – Personal Portfolio
- Collectors Web & Shop – CMS-based e-commerce project

## Changes
- added new CV section "Development Projects"
- implemented consistent HTML structure using existing article layout
- included tech stack and project descriptions
- added links to project websites and GitHub repositories

## Goal
Improve the CV by showcasing real development work and practical experience relevant for junior web developer roles.